### PR TITLE
feat: add directional smoke particle animation to background

### DIFF
--- a/lib/widgets/animated_background.dart
+++ b/lib/widgets/animated_background.dart
@@ -20,7 +20,9 @@ class _AnimatedBackgroundState extends State<AnimatedBackground>
     with TickerProviderStateMixin {
   late AnimationController _particleController;
   late AnimationController _gradientController;
+  late AnimationController _smokeController;
   late List<Particle> _particles;
+  late List<SmokeWisp> _smokeWisps;
   double _smoothedScrollOffset = 0;
   bool _reduceMotion = false;
 
@@ -38,8 +40,18 @@ class _AnimatedBackgroundState extends State<AnimatedBackground>
       vsync: this,
     );
 
+    // Smoke never stops: each wisp perpetually crosses the screen from its
+    // home edge to the far edge, fading in as it enters and out as it
+    // exits, then re-enters from the same edge for another pass — blue
+    // always travels left-to-right, pink always right-to-left.
+    _smokeController = AnimationController(
+      duration: const Duration(seconds: 18),
+      vsync: this,
+    );
+
     // * Initialize particles with a placeholder size, will be updated in build
     _particles = [];
+    _smokeWisps = [];
   }
 
   // Lets the background drift a little slower than the page scrolls — a
@@ -61,9 +73,15 @@ class _AnimatedBackgroundState extends State<AnimatedBackground>
     if (_reduceMotion) {
       _particleController.stop();
       _gradientController.stop();
-    } else if (!_particleController.isAnimating) {
-      _particleController.repeat();
-      _gradientController.repeat();
+      _smokeController.stop();
+    } else {
+      if (!_particleController.isAnimating) {
+        _particleController.repeat();
+        _gradientController.repeat();
+      }
+      if (!_smokeController.isAnimating) {
+        _smokeController.repeat();
+      }
     }
   }
 
@@ -71,6 +89,7 @@ class _AnimatedBackgroundState extends State<AnimatedBackground>
   void dispose() {
     _particleController.dispose();
     _gradientController.dispose();
+    _smokeController.dispose();
     super.dispose();
   }
 
@@ -81,6 +100,9 @@ class _AnimatedBackgroundState extends State<AnimatedBackground>
     // Generate particles based on actual screen size if not already generated
     if (_particles.isEmpty) {
       _particles = List.generate(50, (index) => Particle.random(screenSize));
+    }
+    if (_smokeWisps.isEmpty) {
+      _smokeWisps = List.generate(16, (index) => SmokeWisp.random(screenSize));
     }
 
     return Stack(
@@ -124,6 +146,24 @@ class _AnimatedBackgroundState extends State<AnimatedBackground>
                   particles: _particles,
                   animation: _particleController.value,
                   scrollOffset: _smoothedScrollOffset,
+                ),
+              ),
+            );
+          },
+        ),
+
+        // Smoke: each wisp continuously crosses the screen from its home
+        // edge to the far one and loops — never settles, never stops.
+        AnimatedBuilder(
+          animation: _smokeController,
+          builder: (context, child) {
+            return SizedBox(
+              width: screenSize.width,
+              height: screenSize.height,
+              child: CustomPaint(
+                painter: SmokeBurstPainter(
+                  wisps: _smokeWisps,
+                  progress: _smokeController.value,
                 ),
               ),
             );
@@ -209,4 +249,95 @@ class ParticlePainter extends CustomPainter {
 
   @override
   bool shouldRepaint(ParticlePainter oldDelegate) => true;
+}
+
+/// A single soft smoke puff that perpetually crosses the screen from its
+/// home edge to the far one, fading in as it enters and out as it exits,
+/// then re-entering from the same edge for another pass — it never
+/// settles and never stops moving.
+class SmokeWisp {
+  final bool fromLeft;
+  final double startY;
+  final double verticalAmplitude;
+  final double verticalPhase;
+  final double size;
+  final double peakAlpha;
+  final double phase;
+  final double speed;
+
+  SmokeWisp({
+    required this.fromLeft,
+    required this.startY,
+    required this.verticalAmplitude,
+    required this.verticalPhase,
+    required this.size,
+    required this.peakAlpha,
+    required this.phase,
+    required this.speed,
+  });
+
+  // Blue (accent) always travels from the left edge to the right; pink
+  // (primary) always travels from the right edge to the left. The two
+  // colors never cross sides.
+  Color get color => fromLeft ? AppTheme.accentColor : AppTheme.primaryColor;
+
+  factory SmokeWisp.random(Size screenSize) {
+    final random = math.Random();
+    return SmokeWisp(
+      fromLeft: random.nextBool(),
+      startY: random.nextDouble() * screenSize.height,
+      verticalAmplitude: 30 + random.nextDouble() * 60,
+      verticalPhase: random.nextDouble() * 2 * math.pi,
+      size: 40 + random.nextDouble() * 50,
+      peakAlpha: 0.10 + random.nextDouble() * 0.14,
+      // Small stagger so the first pass still reads as a burst arriving
+      // from the edges, not one synchronized wall of smoke; every pass
+      // after loops naturally from the same formula.
+      phase: random.nextDouble() * 0.35,
+      speed: 0.7 + random.nextDouble() * 0.7,
+    );
+  }
+}
+
+/// Paints the smoke: each wisp's horizontal position is a full crossing of
+/// the screen driven by the looping [progress] clock — [SmokeWisp.speed]
+/// and [SmokeWisp.phase] desync the wisps from each other so crossings
+/// never lock-step, and each fades in/out via a sine envelope that hits
+/// zero exactly at both off-screen endpoints, so the loop reset is
+/// invisible.
+class SmokeBurstPainter extends CustomPainter {
+  final List<SmokeWisp> wisps;
+  final double progress;
+
+  SmokeBurstPainter({required this.wisps, required this.progress});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    for (final wisp in wisps) {
+      final cycleT = (progress * wisp.speed + wisp.phase) % 1.0;
+      final eased = Curves.easeInOut.transform(cycleT);
+
+      final margin = wisp.size;
+      final x = wisp.fromLeft
+          ? -margin + (size.width + margin * 2) * eased
+          : size.width + margin - (size.width + margin * 2) * eased;
+      final y = wisp.startY +
+          math.sin(cycleT * 2 * math.pi + wisp.verticalPhase) *
+              wisp.verticalAmplitude;
+
+      // Zero at cycleT 0 and 1 (off-screen), peak at the midpoint — the
+      // puff is always fully faded before the loop resets it.
+      final opacity = wisp.peakAlpha * math.sin(math.pi * cycleT);
+      if (opacity <= 0) continue;
+
+      final paint = Paint()
+        ..color = wisp.color.withValues(alpha: opacity)
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, wisp.size * 0.5);
+      canvas.drawCircle(Offset(x, y), wisp.size, paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant SmokeBurstPainter oldDelegate) =>
+      oldDelegate.progress != progress;
 }


### PR DESCRIPTION
- Add SmokeWisp model and SmokeBurstPainter to animated_background.dart
- Blue wisps spawn left, travel right; pink wisps spawn right, travel left
- Loop perpetually on a single repeating AnimationController with per-wisp speed/phase desync
- Fade in/out via sin curve that zeroes exactly at off-screen loop endpoints
- Apply MaskFilter.blur for a soft diffuse smoke look
- Stop animating when MediaQuery.disableAnimations is set

Resolves: #16


Claude-Session: https://claude.ai/code/session_01SrAAPDoHXHZGeq9gCihKox