### PR TITLE
fix: center Spotify embed and lengthen hover-preview delay

### DIFF
--- a/lib/widgets/now_cards.dart
+++ b/lib/widgets/now_cards.dart
@@ -79,6 +79,12 @@ class SpotifyTopTracksCard extends StatelessWidget {
   // → playlist → Share → Copy link, the ID is the last path segment).
   static const String _playlistId = '3R8rXgS463C3WLok9VP0Tq';
 
+  // Spotify's compact playlist embed's own natural content height (title
+  // strip + ~4 tracks + player bar) — beyond this it just pads itself with
+  // blank space rather than showing more, so there's no point sizing the
+  // iframe any taller.
+  static const double _spotifyEmbedHeight = 160;
+
   @override
   Widget build(BuildContext context) {
     return _NowCard(
@@ -108,14 +114,18 @@ class SpotifyTopTracksCard extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 12),
-          // Spotify's compact embed is 152px; anything taller reveals more
-          // of the actual tracklist rather than leaving dead space, so this
-          // fills whatever room the matched card height leaves rather than
-          // staying pinned at 152.
+          // Spotify's own embed content tops out well short of the taller
+          // height this card gets matched to (mirroring the Education
+          // column) — stretching the iframe to fill it just leaves dead
+          // space *inside* the iframe, below the player. Expanded + Center,
+          // same fix as ReadingRightNowCard below: give the embed its
+          // natural height and center that within the extra room instead.
           const Expanded(
-            child: SpotifyEmbed(
-              playlistId: _playlistId,
-              height: double.infinity,
+            child: Center(
+              child: SpotifyEmbed(
+                playlistId: _playlistId,
+                height: _spotifyEmbedHeight,
+              ),
             ),
           ),
         ],

--- a/lib/widgets/sections/projects_section.dart
+++ b/lib/widgets/sections/projects_section.dart
@@ -88,9 +88,11 @@ class _ProjectCardState extends State<_ProjectCard>
   bool _isHovered = false;
   late final AnimationController _pulseController;
 
-  // Hover-intent preview (desktop): a short delay before the centered
-  // enlarged-image preview appears, so a mouse merely passing over the
-  // card on its way elsewhere doesn't pop it open.
+  // Hover-intent preview (desktop): a deliberate delay before the centered
+  // enlarged-image preview appears, so it reads as "I'm actually looking at
+  // this one" rather than firing on every pass-through hover on the way to
+  // somewhere else on the page.
+  static const _hoverIntentDelay = Duration(seconds: 3);
   final _previewController = OverlayPortalController();
   Timer? _hoverIntentTimer;
 
@@ -122,7 +124,7 @@ class _ProjectCardState extends State<_ProjectCard>
 
   void _scheduleImagePreview() {
     _hoverIntentTimer?.cancel();
-    _hoverIntentTimer = Timer(const Duration(milliseconds: 220), () {
+    _hoverIntentTimer = Timer(_hoverIntentDelay, () {
       if (mounted) _previewController.show();
     });
   }


### PR DESCRIPTION
- Fix "My Top Tracks" Spotify embed to vertically center within the
  Listening Now card instead of stretching to fill it, which left dead
  space pinned at the bottom of the iframe
- Increase project card hover-intent delay from 220ms to 3s so the
  enlarged image preview only appears on deliberate hover, not
  pass-through

Resolves: #23